### PR TITLE
Feature/mohammed backend - API Endpoints

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,14 +9,18 @@
 			"version": "1.0.0",
 			"license": "ISC",
 			"dependencies": {
+				"@google/generative-ai": "^0.24.1",
 				"better-sqlite3": "^12.8.0",
 				"cookie-parser": "^1.4.7",
+				"cors": "^2.8.6",
+				"dotenv": "^17.3.1",
 				"express": "^5.2.1",
 				"jsonwebtoken": "^9.0.3"
 			},
 			"devDependencies": {
 				"@eslint/js": "^9.28.0",
 				"@types/better-sqlite3": "^7.6.13",
+				"@types/cors": "^2.8.17",
 				"@types/express": "^5.0.6",
 				"@types/jsonwebtoken": "^9.0.10",
 				"@types/node": "^25.5.0",
@@ -580,6 +584,15 @@
 				"url": "https://eslint.org/donate"
 			}
 		},
+		"node_modules/@google/generative-ai": {
+			"version": "0.24.1",
+			"resolved": "https://registry.npmjs.org/@google/generative-ai/-/generative-ai-0.24.1.tgz",
+			"integrity": "sha512-MqO+MLfM6kjxcKoy0p1wRzG3b4ZZXtPI+z2IE26UogS2Cm/XHO+7gGRBh6gcJsOiIVoH93UwKvW4HdgiOZCy9Q==",
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
 		"node_modules/@humanwhocodes/config-array": {
 			"version": "0.13.0",
 			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
@@ -725,6 +738,16 @@
 			"version": "3.4.38",
 			"resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
 			"integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*"
+			}
+		},
+		"node_modules/@types/cors": {
+			"version": "2.8.19",
+			"resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
+			"integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1442,6 +1465,23 @@
 				"node": ">=6.6.0"
 			}
 		},
+		"node_modules/cors": {
+			"version": "2.8.6",
+			"resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+			"integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+			"license": "MIT",
+			"dependencies": {
+				"object-assign": "^4",
+				"vary": "^1"
+			},
+			"engines": {
+				"node": ">= 0.10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
 		"node_modules/cross-spawn": {
 			"version": "7.0.6",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -1534,6 +1574,18 @@
 			},
 			"engines": {
 				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/dotenv": {
+			"version": "17.4.0",
+			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.0.tgz",
+			"integrity": "sha512-kCKF62fwtzwYm0IGBNjRUjtJgMfGapII+FslMHIjMR5KTnwEmBmWLDRSnc3XSNP8bNy34tekgQyDT0hr7pERRQ==",
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://dotenvx.com"
 			}
 		},
 		"node_modules/dunder-proto": {
@@ -2841,6 +2893,15 @@
 			},
 			"engines": {
 				"node": ">=10"
+			}
+		},
+		"node_modules/object-assign": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+			"integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/object-inspect": {

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -861,6 +861,7 @@
 			"integrity": "sha512-30ScMRHIAD33JJQkgfGW1t8CURZtjc2JpTrq5n2HFhOefbAhb7ucc7xJwdWcrEtqUIYJ73Nybpsggii6GtAHjA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@typescript-eslint/scope-manager": "8.57.2",
 				"@typescript-eslint/types": "8.57.2",
@@ -1085,6 +1086,7 @@
 			"integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -1679,6 +1681,7 @@
 			"deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.2.0",
 				"@eslint-community/regexpp": "^4.6.1",
@@ -1735,6 +1738,7 @@
 			"integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"eslint-config-prettier": "bin/cli.js"
 			},
@@ -2990,6 +2994,7 @@
 			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -3040,6 +3045,7 @@
 			"integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"prettier": "bin/prettier.cjs"
 			},
@@ -3736,6 +3742,7 @@
 			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
 			"dev": true,
 			"license": "Apache-2.0",
+			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"

--- a/backend/src/api/api_create_note_post.ts
+++ b/backend/src/api/api_create_note_post.ts
@@ -1,0 +1,44 @@
+import { type Response } from "express";
+import { DB } from "../db/db.js";
+import type { AuthenticatedRequest } from "../types/user.js";
+
+interface CreateNoteRequestBody {
+	title: string;
+	content: string;
+}
+
+export const ApiPostCreateNote = (
+	req: AuthenticatedRequest,
+	res: Response,
+): void  => {	
+
+	if (!req.user) {
+		res.status(401).json({ message: "Unauthorized" });
+		return;
+	}
+
+	const { title, content } = req.body as CreateNoteRequestBody;
+
+	if (typeof title !== "string" || typeof content !== "string") {
+        res.status(400).json({ message: "Invalid data types, need to be strings" });
+        return;
+    }
+
+	const cleanTitle = title.trim();
+
+    if (cleanTitle.length === 0) {
+        res.status(400).json({ message: "Expected non-empty title"});
+        return;
+    }
+
+	const db = DB.Instance();
+	const result = db.CreateNote(req.user.ID, cleanTitle, content);
+
+	if (result.error !== null) {
+		console.error(`error creating note: ${result.error}`);
+		res.status(500).json({ message: "Internal server error" });
+		return;
+	}
+
+	res.status(201).json({ id: result.data });
+};

--- a/backend/src/api/api_delete_note_post.ts
+++ b/backend/src/api/api_delete_note_post.ts
@@ -1,0 +1,37 @@
+import { type Response } from "express";
+import { DB } from "../db/db.js";
+import type { AuthenticatedRequest } from "../types/user.js";   
+
+export const ApiPostDeleteNote = (
+    req: AuthenticatedRequest,
+    res: Response,
+): void => {
+    if (!req.user) {
+        res.status(401).json({ message: "Unauthorized" });
+        return;
+    }
+
+    const idParam = req.params.id;
+    const noteId = Number(idParam);
+
+    if (!idParam || Number.isNaN(noteId) || noteId <= 0) {
+        res.status(400).json({ message: "Invalid note id"});
+        return;
+    }
+
+    const db = DB.Instance();
+    const result = db.DeleteNote(noteId, req.user.ID);
+
+    if (result.error !== null) {
+        console.error(`error deleting note: ${result.error}`);
+        res.status(500).json({ message: "Internal server error" });
+        return;
+    }
+
+    if (result.data === 0) {
+		res.status(404).json({ message: "Note not found" });
+		return;
+	}
+
+    res.status(200).json({ id: noteId });
+};

--- a/backend/src/api/api_note_get.ts
+++ b/backend/src/api/api_note_get.ts
@@ -1,0 +1,37 @@
+import { type Response } from "express";
+import { DB } from "../db/db.js";
+import type { AuthenticatedRequest } from "../types/user.js";
+
+export const ApiGetNote = (
+    req: AuthenticatedRequest,
+    res: Response,
+): void => {
+    if (!req.user) {
+        res.status(401).json({ message: "Unauthorized" });
+        return;
+    }
+
+    const idParam = req.params.id;
+    const noteId = Number(idParam);
+
+    if (!idParam || Number.isNaN(noteId) || noteId <= 0) {
+        res.status(400).json({ message: "Invalid note id" });
+        return;
+    }
+
+    const db = DB.Instance();
+    const result = db.GetSingleNote(noteId, req.user.ID);
+
+    if (result.error !== null) {
+        console.error(`error retrieving note: ${result.error}`);
+        res.status(500).json({ message: "Internal server error" });
+        return;
+    }
+
+    if (!result.data) {
+        res.status(404).json({ message: "Note not found" });
+        return;
+    }
+
+    res.status(200).json(result.data);
+}; 

--- a/backend/src/api/api_notes_list_get.ts
+++ b/backend/src/api/api_notes_list_get.ts
@@ -1,0 +1,24 @@
+import { type Response } from "express";
+import { DB } from "../db/db.js";
+import type { AuthenticatedRequest } from "../types/user.js";
+
+export const ApiGetNotesList = (
+	req: AuthenticatedRequest,
+	res: Response,
+): void => {
+	if (!req.user) {
+		res.status(401).json({ message: "Unauthorized" });
+		return;
+	}
+
+	const db = DB.Instance();
+	const result = db.GetNotesList(req.user.ID);
+
+	if (result.error !== null) {
+		console.error(`error listing notes: ${result.error}`);
+		res.status(500).json({ message: "Internal server error" });
+		return;
+	}
+
+	res.status(200).json(result.data);
+};

--- a/backend/src/api/api_update_note_post.ts
+++ b/backend/src/api/api_update_note_post.ts
@@ -1,0 +1,63 @@
+import { type Response } from "express";
+import { DB } from "../db/db.js";
+import type { AuthenticatedRequest } from "../types/user.js";
+
+interface UpdateNoteRequestBody {
+	title: string;
+	content: string;
+}
+
+export const ApiPostUpdateNote = (
+	req: AuthenticatedRequest,
+	res: Response,
+): void => {
+	if (!req.user) {
+		res.status(401).json({ message: "Unauthorized" });
+		return;
+	}
+
+	const idParam = req.params.id;
+	const noteId = Number(idParam);
+
+	if (!idParam || Number.isNaN(noteId) || noteId <= 0) {
+		res.status(400).json({ message: "Invalid note id" });
+		return;
+	}
+
+	const { title, content } = req.body as UpdateNoteRequestBody;
+
+	if (typeof title !== "string" || typeof content !== "string") {
+		res.status(400).json({ message: "Invalid data types, need to be strings" });
+		return;
+	}
+
+	const cleanTitle = title.trim();
+
+	if (cleanTitle.length === 0) {
+		res.status(400).json({ message: "Expected non-empty title" });
+		return;
+	}
+
+	const db = DB.Instance();
+	const result = db.UpdateNote(noteId, req.user.ID, cleanTitle, content);
+
+	if (result.error !== null) {
+		console.error(`error updating note: ${result.error}`);
+		res.status(500).json({ message: "Internal server error" });
+		return;
+	}
+
+	if (result.data === 0) {
+		res.status(404).json({ message: "Note not found" });
+		return;
+	}
+
+	const updatedNote = db.GetSingleNote(noteId, req.user.ID);
+
+	if (updatedNote.error !== null || !updatedNote.data) {
+		res.status(500).json({ message: "Internal server error" });
+		return;
+	}
+	
+	res.status(200).json(updatedNote.data);
+};

--- a/backend/src/db/db.ts
+++ b/backend/src/db/db.ts
@@ -3,6 +3,7 @@ import { DBError } from "./errors.js";
 import { Migrations } from "./migrations.js";
 import crypto from "crypto";
 import type { User } from "../types/user.js";
+import type { Note } from "../types/note.js";
 
 export type Result<T> =
 	| { data: T; error: null }
@@ -60,6 +61,7 @@ export class DB {
 			return { data: null, error: DBError.from(err) };
 		}
 	}
+
 	public AddUser(
 		username: string,
 		email: string,
@@ -82,6 +84,80 @@ export class DB {
 			return { data: Number(info.lastInsertRowid), error: null };
 		} catch (err) {
 			return { data: null, error: DBError.from(err) };
+		}
+	}
+
+	public CreateNote(userId: number, title: string, content: string): Result<number> {
+		try {
+			const stmt = this.db.prepare(
+				"INSERT INTO DB_NOTES (USER_ID, TITLE, CONTENT) VALUES (?, ?, ?)",
+			);
+
+			const info = stmt.run(userId, title, content);
+
+			return { data: Number(info.lastInsertRowid), error: null };
+		} catch (err) {
+			return { data: null, error: DBError.from(err) };
+		}	
+	}
+
+	public GetNotes(userId: number): Result<Note[]> {
+		try {
+			const stmt = this.db.prepare(
+				"SELECT ID, USER_ID, TITLE, CONTENT, CREATED, UPDATED FROM DB_NOTES WHERE USER_ID = ?",
+			);
+
+			const rows = stmt.all(userId) as Note[];
+
+			return { data: rows, error: null};				
+		} catch (err) {
+			return { data: null, error: DBError.from(err) };
+		}
+	}
+
+	public GetSingleNote(noteId: number, userId: number): Result<Note> {
+		try {
+			const stmt = this.db.prepare(
+				"SELECT ID, USER_ID, TITLE, CONTENT, CREATED, UPDATED FROM DB_NOTES WHERE ID = ? AND USER_ID = ?",
+			);
+
+			const row = stmt.get(noteId, userId) as Note;
+
+			return { data: row, error: null };
+		} catch (err) {
+			return { data: null, error: DBError.from(err) };
+		}
+	}
+
+	public UpdateNote(noteId: number, userId: number, title: string, content: string): Result<number> {
+		try {
+			const stmt = this.db.prepare(
+				`UPDATE DB_NOTES
+				 SET TITLE = ?,
+				 	 CONTENT = ?,
+					 UPDATED = CURRENT_TIMESTAMP
+			 	 WHERE ID = ? AND USER_ID = ?`
+			);
+
+			const row = stmt.run(title, content, noteId, userId);
+
+			return { data: row.changes, error: null};
+		} catch (err) {
+			return { data: null, error: DBError.from(err)};
+		}
+	} 
+
+	public DeleteNote(noteId: number, userId: number): Result<number> {
+		try {
+			const stmt = this.db.prepare(
+				"DELETE FROM DB_NOTES WHERE ID = ? AND USER_ID = ?",
+			);
+
+			const row = stmt.run(noteId, userId);
+
+			return { data: row.changes, error: null};
+		} catch (err) {
+			return { data: null, error: DBError.from(err)};
 		}
 	}
 

--- a/backend/src/db/db.ts
+++ b/backend/src/db/db.ts
@@ -3,7 +3,7 @@ import { DBError } from "./errors.js";
 import { Migrations } from "./migrations.js";
 import crypto from "crypto";
 import type { User } from "../types/user.js";
-import type { Note } from "../types/note.js";
+import type { Note, NoteListItem } from "../types/note.js";
 
 export type Result<T> =
 	| { data: T; error: null }
@@ -101,10 +101,10 @@ export class DB {
 		}	
 	}
 
-	public GetNotes(userId: number): Result<Note[]> {
+	public GetNotesList(userId: number): Result<NoteListItem[]> {
 		try {
 			const stmt = this.db.prepare(
-				"SELECT ID, USER_ID, TITLE, CONTENT, CREATED, UPDATED FROM DB_NOTES WHERE USER_ID = ?",
+				"SELECT ID, TITLE, UPDATED FROM DB_NOTES WHERE USER_ID = ? ORDER BY UPDATED DESC",
 			);
 
 			const rows = stmt.all(userId) as Note[];

--- a/backend/src/db/db.ts
+++ b/backend/src/db/db.ts
@@ -104,7 +104,12 @@ export class DB {
 	public GetNotesList(userId: number): Result<NoteListItem[]> {
 		try {
 			const stmt = this.db.prepare(
-				"SELECT ID, TITLE, UPDATED FROM DB_NOTES WHERE USER_ID = ? ORDER BY UPDATED DESC",
+				`SELECT 
+					ID AS id, 
+					TITLE AS title, 
+					UPDATED AS updated_at
+					FROM DB_NOTES 
+					WHERE USER_ID = ? ORDER BY UPDATED DESC`,
 			);
 
 			const rows = stmt.all(userId) as NoteListItem[];
@@ -118,7 +123,14 @@ export class DB {
 	public GetSingleNote(noteId: number, userId: number): Result<Note> {
 		try {
 			const stmt = this.db.prepare(
-				"SELECT ID, USER_ID, TITLE, CONTENT, CREATED, UPDATED FROM DB_NOTES WHERE ID = ? AND USER_ID = ?",
+				`SELECT 
+					ID AS id, 
+					TITLE AS title, 
+					CONTENT AS content, 
+					CREATED AS created_at, 
+					UPDATED AS updated_at 
+				 FROM DB_NOTES 
+				 WHERE ID = ? AND USER_ID = ?`,
 			);
 
 			const row = stmt.get(noteId, userId) as Note;

--- a/backend/src/db/migrations.ts
+++ b/backend/src/db/migrations.ts
@@ -66,6 +66,40 @@ const migrate_1: MigrationFunc = (
 	return null;
 };
 
+const migrate_2: MigrationFunc = (
+	database: DB,
+	fromVersion: number,
+	toVersion: number,
+) => {
+    const db = database.DB();
+
+	try {
+		const tx = db.transaction (() => {
+			db.exec(
+				`CREATE TABLE IF NOT EXISTS DB_NOTES (
+					ID INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+					USER_ID INTEGER NOT NULL,
+					TITLE TEXT NOT NULL,
+					CONTENT TEXT NOT NULL DEFAULT "",
+					CREATED TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+					UPDATED TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+					FOREIGN KEY (USER_ID) REFERENCES DB_USER(ID) ON DELETE CASCADE
+				)`
+			);
+			
+			db.prepare(
+				"UPDATE DB_VERSION SET VERSION = ? WHERE VERSION = ?",
+			).run(toVersion, fromVersion);
+		});
+
+		tx();
+		
+	} catch (err) {
+		return DBError.from(err);
+	}
+
+	return null;
+};
 export const Migrations: Array<{
 	fromVersion: number;
 	toVersion: number;
@@ -73,4 +107,5 @@ export const Migrations: Array<{
 }> = [
 	{ fromVersion: 0, toVersion: 1, func: migrate_0 },
 	{ fromVersion: 1, toVersion: 2, func: migrate_1 },
+	{ fromVersion: 2, toVersion: 3, func: migrate_2 },
 ];

--- a/backend/src/db/migrations.ts
+++ b/backend/src/db/migrations.ts
@@ -100,6 +100,7 @@ const migrate_2: MigrationFunc = (
 
 	return null;
 };
+
 export const Migrations: Array<{
 	fromVersion: number;
 	toVersion: number;

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -6,6 +6,11 @@ import { ApiPostLogin } from "./api/api_login_post.js";
 import { ApiPostCreateUser } from "./api/api_create_user_post.js";
 import { MiddleWareAuthenticateToken } from "./middleware/auth.js";
 import { ApiGetWhoAmI } from "./api/api_whoami_get.js";
+import { ApiGetNote } from "./api/api_note_get.js";
+import { ApiGetNotesList } from "./api/api_notes_list_get.js";
+import { ApiPostCreateNote } from "./api/api_create_note_post.js";
+import { ApiPostUpdateNote } from "./api/api_update_note_post.js";
+import { ApiPostDeleteNote } from "./api/api_delete_note_post.js";
 
 // ── David's routes ────────────────────────────────────────────────────────────
 import analyzeRouter from "./routes/analyze.js";
@@ -35,6 +40,13 @@ ExpressApp.get("/", (req: Request, res: Response) => {
 ExpressApp.post("/api/login", ApiPostLogin);
 ExpressApp.post("/api/register", ApiPostCreateUser);
 ExpressApp.get("/api/whoami", MiddleWareAuthenticateToken, ApiGetWhoAmI);
+
+// API endpoints for notes
+ExpressApp.get("/api/notes", MiddleWareAuthenticateToken, ApiGetNotesList);
+ExpressApp.post("/api/notes", MiddleWareAuthenticateToken, ApiPostCreateNote);
+ExpressApp.get("/api/notes/:id", MiddleWareAuthenticateToken, ApiGetNote);
+ExpressApp.post("/api/notes/:id/update", MiddleWareAuthenticateToken, ApiPostUpdateNote);
+ExpressApp.post("/api/notes/:id/delete", MiddleWareAuthenticateToken, ApiPostDeleteNote);
 
 ExpressApp.listen(PORT, () => {
 	console.log(`Server running at http://localhost:${PORT}`);

--- a/backend/src/types/note.ts
+++ b/backend/src/types/note.ts
@@ -7,3 +7,9 @@ export type Note = {
 	UPDATED: string;
 };
 
+export type NoteListItem = {
+	ID: number;
+	TITLE: string;
+	UPDATED: string;
+};
+

--- a/backend/src/types/note.ts
+++ b/backend/src/types/note.ts
@@ -1,0 +1,9 @@
+export type Note = {
+	ID: number;
+	USER_ID: number;
+	TITLE: string;
+	CONTENT: string;
+	CREATED: string;
+	UPDATED: string;
+};
+

--- a/backend/src/types/note.ts
+++ b/backend/src/types/note.ts
@@ -1,15 +1,14 @@
 export type Note = {
-	ID: number;
-	USER_ID: number;
-	TITLE: string;
-	CONTENT: string;
-	CREATED: string;
-	UPDATED: string;
-};
-
-export type NoteListItem = {
-	ID: number;
-	TITLE: string;
-	UPDATED: string;
-};
+	id: number;
+	title: string;
+	content: string;
+	created_at: string;
+	updated_at: string;
+  };
+  
+  export type NoteListItem = {
+	id: number;
+	title: string;
+	updated_at: string;
+  };
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -163,7 +163,6 @@
       "version": "0.122.0",
       "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.122.0.tgz",
       "integrity": "sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
@@ -176,7 +175,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -193,7 +191,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -210,7 +207,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -227,7 +223,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -244,7 +239,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -261,7 +255,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -278,7 +271,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -295,7 +287,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -312,7 +303,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -329,7 +319,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -346,7 +335,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -363,7 +351,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -380,7 +367,6 @@
       "cpu": [
         "wasm32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -397,7 +383,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -414,7 +399,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1153,6 +1137,7 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -1290,7 +1275,6 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -1308,7 +1292,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -1700,8 +1683,8 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1756,7 +1739,6 @@
       "version": "1.0.0-rc.11",
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.11.tgz",
       "integrity": "sha512-NRjoKMusSjfRbSYiH3VSumlkgFe7kYAa3pzVOsVYVFY3zb5d7nS+a3KGQ7hJKXuYWbzJKPVQ9Wxq2UvyK+ENpw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@oxc-project/types": "=0.122.0",
@@ -1790,7 +1772,6 @@
       "version": "1.0.0-rc.11",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.11.tgz",
       "integrity": "sha512-xQO9vbwBecJRv9EUcQ/y0dzSTJgA7Q6UVN7xp6B81+tBGSLVAK03yJ9NkJaUA7JFD91kbjxRSC/mDnmvXzbHoQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/rw": {
@@ -1837,7 +1818,6 @@
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
       "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -1867,8 +1847,8 @@
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.2.tgz",
       "integrity": "sha512-1gFhNi+bHhRE/qKZOJXACm6tX4bA3Isy9KuKF15AgSRuRazNBOJfdDemPBU16/mpMxApDPrWvZ08DcLPEoRnuA==",
-      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.3",
@@ -1946,6 +1926,7 @@
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.30.tgz",
       "integrity": "sha512-hTHLc6VNZyzzEH/l7PFGjpcTvUgiaPK5mdLkbjrTeWSRcEfxFrv56g/XckIYlE9ckuobsdwqd5mk2g1sBkMewg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.30",
         "@vue/compiler-sfc": "3.5.30",


### PR DESCRIPTION
* Added authenticated backend routes for note CRUD operations:
  * `GET /api/notes`
  * `POST /api/notes`
  * `GET /api/notes/:id`
  * `POST /api/notes/:id/update`
  * `POST /api/notes/:id/delete`
* Implemented note CRUD data access in the backend DB layer.
* Mapped database response fields to match frontend expectations (`id`, `title`, `content`, `created_at`, `updated_at`).


Closes #14

Closes #18