### PR TITLE
feat: tag system backend + refresh/loading fixes

### DIFF
--- a/USER_STORIES.md
+++ b/USER_STORIES.md
@@ -25,6 +25,14 @@
 
 - As a user, I want to see my recently visited notes so that I can quickly return to active work
 
+## Tags
+
+- As a user, I want to type #tagname in my notes so that I can tag them inline
+- As a user, I want to see tag autocomplete when I type # so that I can reuse existing tags quickly
+- As a user, I want new tags I type to be added to a global tag list automatically
+- As a user, I want to view and manage my global tag list so that I can add or remove tags directly
+- As a user, I want to auto-tag a note using AI so that relevant tags are suggested from my global list
+
 ## Visualisations
 
 - As a user, I want to search my notes using keywords so that I can find relevant notes quickly

--- a/backend/scripts/seedNotes.ts
+++ b/backend/scripts/seedNotes.ts
@@ -108,7 +108,7 @@ const insertNote = db.prepare(
 	"INSERT INTO DB_NOTES (USER_ID, TITLE, CONTENT) VALUES (?, ?, ?)",
 );
 const insertFts = db.prepare(
-	"INSERT INTO notes_fts (note_id, title, tags, content) VALUES (?, ?, ?, ?)",
+	"INSERT INTO notes_fts (note_id, title, content) VALUES (?, ?, ?)",
 );
 
 const seed = db.transaction(() => {
@@ -120,7 +120,7 @@ const seed = db.transaction(() => {
 		}
 		const result = insertNote.run(userId, note.title, note.content);
 		const noteId = Number(result.lastInsertRowid);
-		insertFts.run(noteId, note.title, "", note.content);
+		insertFts.run(noteId, note.title, note.content);
 		console.log(`  added: "${note.title}" (id: ${noteId})`);
 		inserted++;
 	}

--- a/backend/src/api/api_note_tags_get.ts
+++ b/backend/src/api/api_note_tags_get.ts
@@ -1,0 +1,32 @@
+import { type Response } from "express";
+import { DB } from "../db/db.js";
+import type { AuthenticatedRequest } from "../types/user.js";
+
+export const ApiGetNoteTags = (
+	req: AuthenticatedRequest,
+	res: Response,
+): void => {
+	if (!req.user) {
+		res.status(401).json({ message: "Unauthorized" });
+		return;
+	}
+
+	const idParam = req.params.id;
+	const noteId = Number(idParam);
+
+	if (!idParam || Number.isNaN(noteId) || noteId <= 0) {
+		res.status(400).json({ message: "Invalid note id" });
+		return;
+	}
+
+	const db = DB.Instance();
+	const result = db.GetNoteTags(noteId, req.user.ID);
+
+	if (result.error !== null) {
+		console.error(`error getting note tags: ${result.error}`);
+		res.status(500).json({ message: "Internal server error" });
+		return;
+	}
+
+	res.status(200).json({ tags: result.data });
+};

--- a/backend/src/api/api_note_tags_post.ts
+++ b/backend/src/api/api_note_tags_post.ts
@@ -1,0 +1,43 @@
+import { type Response } from "express";
+import { DB } from "../db/db.js";
+import type { AuthenticatedRequest } from "../types/user.js";
+
+export const ApiPostNoteTags = (
+	req: AuthenticatedRequest,
+	res: Response,
+): void => {
+	if (!req.user) {
+		res.status(401).json({ message: "Unauthorized" });
+		return;
+	}
+
+	const idParam = req.params.id;
+	const noteId = Number(idParam);
+
+	if (!idParam || Number.isNaN(noteId) || noteId <= 0) {
+		res.status(400).json({ message: "Invalid note id" });
+		return;
+	}
+
+	const { tags } = req.body as { tags?: unknown };
+
+	if (!Array.isArray(tags)) {
+		res.status(400).json({ message: "tags must be an array" });
+		return;
+	}
+
+	const db = DB.Instance();
+	const result = db.SyncNoteTags(noteId, req.user.ID, tags as string[]);
+
+	if (result.error !== null) {
+		if (result.error.message === "Note not found") {
+			res.status(404).json({ message: "Note not found" });
+			return;
+		}
+		console.error(`error syncing note tags: ${result.error}`);
+		res.status(500).json({ message: "Internal server error" });
+		return;
+	}
+
+	res.status(200).json({ tags: result.data });
+};

--- a/backend/src/api/api_tag_delete.ts
+++ b/backend/src/api/api_tag_delete.ts
@@ -1,0 +1,37 @@
+import { type Response } from "express";
+import { DB } from "../db/db.js";
+import type { AuthenticatedRequest } from "../types/user.js";
+
+export const ApiPostDeleteTag = (
+	req: AuthenticatedRequest,
+	res: Response,
+): void => {
+	if (!req.user) {
+		res.status(401).json({ message: "Unauthorized" });
+		return;
+	}
+
+	const idParam = req.params.id;
+	const tagId = Number(idParam);
+
+	if (!idParam || Number.isNaN(tagId) || tagId <= 0) {
+		res.status(400).json({ message: "Invalid tag id" });
+		return;
+	}
+
+	const db = DB.Instance();
+	const result = db.DeleteTag(req.user.ID, tagId);
+
+	if (result.error !== null) {
+		console.error(`error deleting tag: ${result.error}`);
+		res.status(500).json({ message: "Internal server error" });
+		return;
+	}
+
+	if (result.data === 0) {
+		res.status(404).json({ message: "Tag not found" });
+		return;
+	}
+
+	res.status(200).json({ id: tagId });
+};

--- a/backend/src/api/api_tag_post.ts
+++ b/backend/src/api/api_tag_post.ts
@@ -1,0 +1,28 @@
+import { type Response } from "express";
+import { DB } from "../db/db.js";
+import type { AuthenticatedRequest } from "../types/user.js";
+
+export const ApiPostTag = (req: AuthenticatedRequest, res: Response): void => {
+	if (!req.user) {
+		res.status(401).json({ message: "Unauthorized" });
+		return;
+	}
+
+	const { name } = req.body as { name?: string };
+
+	if (!name || name.trim().length === 0) {
+		res.status(400).json({ message: "Tag name is required" });
+		return;
+	}
+
+	const db = DB.Instance();
+	const result = db.UpsertTag(req.user.ID, name);
+
+	if (result.error !== null) {
+		console.error(`error creating tag: ${result.error}`);
+		res.status(500).json({ message: "Internal server error" });
+		return;
+	}
+
+	res.status(200).json({ id: result.data, name: name.toLowerCase().trim() });
+};

--- a/backend/src/api/api_tags_get.ts
+++ b/backend/src/api/api_tags_get.ts
@@ -1,0 +1,21 @@
+import { type Response } from "express";
+import { DB } from "../db/db.js";
+import type { AuthenticatedRequest } from "../types/user.js";
+
+export const ApiGetTags = (req: AuthenticatedRequest, res: Response): void => {
+	if (!req.user) {
+		res.status(401).json({ message: "Unauthorized" });
+		return;
+	}
+
+	const db = DB.Instance();
+	const result = db.GetTags(req.user.ID);
+
+	if (result.error !== null) {
+		console.error(`error getting tags: ${result.error}`);
+		res.status(500).json({ message: "Internal server error" });
+		return;
+	}
+
+	res.status(200).json({ tags: result.data });
+};

--- a/backend/src/db/db.ts
+++ b/backend/src/db/db.ts
@@ -108,18 +108,173 @@ export class DB {
 	public GetNotesList(userId: number): Result<NoteListItem[]> {
 		try {
 			const stmt = this.db.prepare(
-				`SELECT 
-					ID AS id, 
-                    PARENT_ID AS folder_id,
-					TITLE AS title, 
-					UPDATED AS updated_at
-					FROM DB_NOTES 
-					WHERE USER_ID = ? ORDER BY UPDATED DESC`,
+				`SELECT
+					n.ID        AS id,
+					n.PARENT_ID AS folder_id,
+					n.TITLE     AS title,
+					n.UPDATED   AS updated_at,
+					GROUP_CONCAT(t.NAME) AS tags
+				FROM DB_NOTES n
+				LEFT JOIN DB_NOTE_TAGS nt ON nt.NOTE_ID = n.ID
+				LEFT JOIN DB_TAGS t       ON t.ID = nt.TAG_ID
+				WHERE n.USER_ID = ?
+				GROUP BY n.ID
+				ORDER BY n.UPDATED DESC`,
 			);
 
-			const rows = stmt.all(userId) as NoteListItem[];
+			const rows = stmt.all(userId) as Array<
+				Omit<NoteListItem, "tags"> & { tags: string | null }
+			>;
+
+			return {
+				data: rows.map((r) => ({
+					...r,
+					tags: r.tags ? r.tags.split(",") : [],
+				})),
+				error: null,
+			};
+		} catch (err) {
+			return { data: null, error: DBError.from(err) };
+		}
+	}
+
+	public GetTags(
+		userId: number,
+	): Result<Array<{ id: number; name: string; note_count: number }>> {
+		try {
+			const stmt = this.db.prepare(
+				`SELECT t.ID AS id, t.NAME AS name, COUNT(nt.NOTE_ID) AS note_count
+				FROM DB_TAGS t
+				LEFT JOIN DB_NOTE_TAGS nt ON nt.TAG_ID = t.ID
+				WHERE t.USER_ID = ?
+				GROUP BY t.ID
+				ORDER BY t.NAME ASC`,
+			);
+
+			const rows = stmt.all(userId) as Array<{
+				id: number;
+				name: string;
+				note_count: number;
+			}>;
 
 			return { data: rows, error: null };
+		} catch (err) {
+			return { data: null, error: DBError.from(err) };
+		}
+	}
+
+	public UpsertTag(userId: number, name: string): Result<number> {
+		try {
+			const normalized = name.toLowerCase().trim();
+
+			this.db
+				.prepare(
+					`INSERT INTO DB_TAGS (USER_ID, NAME) VALUES (?, ?)
+					ON CONFLICT(USER_ID, NAME) DO NOTHING`,
+				)
+				.run(userId, normalized);
+
+			const row = this.db
+				.prepare(`SELECT ID FROM DB_TAGS WHERE USER_ID = ? AND NAME = ?`)
+				.get(userId, normalized) as { ID: number };
+
+			return { data: row.ID, error: null };
+		} catch (err) {
+			return { data: null, error: DBError.from(err) };
+		}
+	}
+
+	public DeleteTag(userId: number, tagId: number): Result<number> {
+		try {
+			const info = this.db
+				.prepare(`DELETE FROM DB_TAGS WHERE ID = ? AND USER_ID = ?`)
+				.run(tagId, userId);
+
+			return { data: info.changes, error: null };
+		} catch (err) {
+			return { data: null, error: DBError.from(err) };
+		}
+	}
+
+	public GetNoteTags(
+		noteId: number,
+		userId: number,
+	): Result<Array<{ id: number; name: string }>> {
+		try {
+			const stmt = this.db.prepare(
+				`SELECT t.ID AS id, t.NAME AS name
+				FROM DB_TAGS t
+				JOIN DB_NOTE_TAGS nt ON nt.TAG_ID = t.ID
+				JOIN DB_NOTES n      ON n.ID = nt.NOTE_ID
+				WHERE nt.NOTE_ID = ? AND n.USER_ID = ?
+				ORDER BY t.NAME ASC`,
+			);
+
+			const rows = stmt.all(noteId, userId) as Array<{
+				id: number;
+				name: string;
+			}>;
+
+			return { data: rows, error: null };
+		} catch (err) {
+			return { data: null, error: DBError.from(err) };
+		}
+	}
+
+	public SyncNoteTags(
+		noteId: number,
+		userId: number,
+		tagNames: string[],
+	): Result<Array<{ id: number; name: string }>> {
+		try {
+			const normalized = tagNames
+				.map((n) => n.toLowerCase().trim())
+				.filter((n) => n.length > 0);
+
+			const upsertTag = this.db.prepare(
+				`INSERT INTO DB_TAGS (USER_ID, NAME) VALUES (?, ?)
+				ON CONFLICT(USER_ID, NAME) DO NOTHING`,
+			);
+			const getTagId = this.db.prepare(
+				`SELECT ID FROM DB_TAGS WHERE USER_ID = ? AND NAME = ?`,
+			);
+			const deleteOldTags = this.db.prepare(
+				`DELETE FROM DB_NOTE_TAGS WHERE NOTE_ID = ?`,
+			);
+			const insertNoteTag = this.db.prepare(
+				`INSERT INTO DB_NOTE_TAGS (NOTE_ID, TAG_ID) VALUES (?, ?)`,
+			);
+
+			const ownerCheck = this.db.prepare(
+				`SELECT ID FROM DB_NOTES WHERE ID = ? AND USER_ID = ?`,
+			);
+
+			const result = this.db.transaction(() => {
+				const owned = ownerCheck.get(noteId, userId);
+				if (!owned) return null;
+
+				const tags: Array<{ id: number; name: string }> = [];
+
+				for (const name of normalized) {
+					upsertTag.run(userId, name);
+					const row = getTagId.get(userId, name) as { ID: number };
+					tags.push({ id: row.ID, name });
+				}
+
+				deleteOldTags.run(noteId);
+
+				for (const tag of tags) {
+					insertNoteTag.run(noteId, tag.id);
+				}
+
+				return tags;
+			})();
+
+			if (result === null) {
+				return { data: null, error: new DBError("Note not found") };
+			}
+
+			return { data: result, error: null };
 		} catch (err) {
 			return { data: null, error: DBError.from(err) };
 		}

--- a/backend/src/db/migrations.ts
+++ b/backend/src/db/migrations.ts
@@ -103,7 +103,7 @@ const migrate_2: MigrationFunc = (
 // ── Migration 3 (David) ───────────────────────────────────────────────────────
 // Creates the notes_fts FTS5 virtual table for hybrid keyword search.
 // Porter stemmer: "running" and "run" match the same note.
-// Field weights via bm25(): title=10×, tags=5×, content=1×.
+// Field weights via bm25(): title=10×, content=1×.
 const migrate_3: MigrationFunc = (
 	database: DB,
 	fromVersion: number,
@@ -117,7 +117,6 @@ const migrate_3: MigrationFunc = (
 				CREATE VIRTUAL TABLE IF NOT EXISTS notes_fts USING fts5(
 					note_id  UNINDEXED,
 					title,
-					tags,
 					content,
 					tokenize = 'porter ascii'
 				)
@@ -221,6 +220,49 @@ const migrate_5: MigrationFunc = (
 	return null;
 };
 
+const migrate_6: MigrationFunc = (
+	database: DB,
+	fromVersion: number,
+	toVersion: number,
+) => {
+	const db = database.DB();
+
+	try {
+		const tx = db.transaction(() => {
+			db.exec(`
+				CREATE TABLE IF NOT EXISTS DB_TAGS (
+					ID       INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+					USER_ID  INTEGER NOT NULL,
+					NAME     TEXT NOT NULL,
+					CREATED  TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+					UNIQUE(USER_ID, NAME),
+					FOREIGN KEY (USER_ID) REFERENCES DB_USER(ID) ON DELETE CASCADE
+				)
+			`);
+
+			db.exec(`
+				CREATE TABLE IF NOT EXISTS DB_NOTE_TAGS (
+					NOTE_ID  INTEGER NOT NULL,
+					TAG_ID   INTEGER NOT NULL,
+					PRIMARY KEY (NOTE_ID, TAG_ID),
+					FOREIGN KEY (NOTE_ID) REFERENCES DB_NOTES(ID) ON DELETE CASCADE,
+					FOREIGN KEY (TAG_ID)  REFERENCES DB_TAGS(ID)  ON DELETE CASCADE
+				)
+			`);
+
+			db.prepare(
+				"UPDATE DB_VERSION SET VERSION = ? WHERE VERSION = ?",
+			).run(toVersion, fromVersion);
+		});
+
+		tx();
+	} catch (err) {
+		return DBError.from(err);
+	}
+
+	return null;
+};
+
 export const Migrations: Array<{
 	fromVersion: number;
 	toVersion: number;
@@ -232,4 +274,5 @@ export const Migrations: Array<{
 	{ fromVersion: 3, toVersion: 4, func: migrate_3 },
 	{ fromVersion: 4, toVersion: 5, func: migrate_4 },
 	{ fromVersion: 5, toVersion: 6, func: migrate_5 },
+	{ fromVersion: 6, toVersion: 7, func: migrate_6 },
 ];

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -21,6 +21,11 @@ import { ApiPostDeleteNoteLinks } from "./api/api_delete_link_note_post.js";
 import { ApiGetNoteLinks } from "./api/api_note_links_get.js";
 import { ApiPostCreateFolder } from "./api/api_create_folder_post.js";
 import { ApiPostDeleteFolder } from "./api/api_delete_folder_post.js";
+import { ApiGetTags } from "./api/api_tags_get.js";
+import { ApiPostTag } from "./api/api_tag_post.js";
+import { ApiPostDeleteTag } from "./api/api_tag_delete.js";
+import { ApiGetNoteTags } from "./api/api_note_tags_get.js";
+import { ApiPostNoteTags } from "./api/api_note_tags_post.js";
 
 export const ExpressApp = express();
 const PORT = 3000;
@@ -86,6 +91,25 @@ ExpressApp.post(
 	"/api/folder/delete",
 	MiddleWareAuthenticateToken,
 	ApiPostDeleteFolder,
+);
+
+// ── Tag endpoints (David) ─────────────────────────────────────────────────────
+ExpressApp.get("/api/tags", MiddleWareAuthenticateToken, ApiGetTags);
+ExpressApp.post("/api/tags", MiddleWareAuthenticateToken, ApiPostTag);
+ExpressApp.post(
+	"/api/tags/:id/delete",
+	MiddleWareAuthenticateToken,
+	ApiPostDeleteTag,
+);
+ExpressApp.get(
+	"/api/notes/:id/tags",
+	MiddleWareAuthenticateToken,
+	ApiGetNoteTags,
+);
+ExpressApp.post(
+	"/api/notes/:id/tags",
+	MiddleWareAuthenticateToken,
+	ApiPostNoteTags,
 );
 
 ExpressApp.listen(PORT, () => {

--- a/backend/src/routes/noteIndex.ts
+++ b/backend/src/routes/noteIndex.ts
@@ -15,11 +15,9 @@ router.post("/notes/:id/index", (req: Request, res: Response) => {
 	const { id } = req.params;
 	const {
 		title = "",
-		tags = "",
 		content = "",
 	} = req.body as {
 		title?: string;
-		tags?: string;
 		content?: string;
 	};
 
@@ -29,8 +27,8 @@ router.post("/notes/:id/index", (req: Request, res: Response) => {
 		const tx = db.transaction(() => {
 			db.prepare("DELETE FROM notes_fts WHERE note_id = ?").run(id);
 			db.prepare(
-				"INSERT INTO notes_fts (note_id, title, tags, content) VALUES (?, ?, ?, ?)",
-			).run(id, title, tags, content);
+				"INSERT INTO notes_fts (note_id, title, content) VALUES (?, ?, ?)",
+			).run(id, title, content);
 		});
 		tx();
 

--- a/backend/src/types/note.ts
+++ b/backend/src/types/note.ts
@@ -9,8 +9,10 @@ export type Note = {
 
 export type NoteListItem = {
 	id: number;
+	folder_id: number | null;
 	title: string;
 	updated_at: string;
+	tags: string[];
 };
 
 export type NoteLink = {

--- a/frontend/src/components/Dashboard.vue
+++ b/frontend/src/components/Dashboard.vue
@@ -24,7 +24,8 @@ import AppButton from './AppButton.vue'
 import { useEditorStore } from '../composables/useEditorStore'
 
 const router = useRouter()
-const { createFile, setActiveFile, recentFiles } = useEditorStore()
+const { createFile, setActiveFile, recentFiles, loading, init } = useEditorStore()
+onMounted(init)
 
 async function handleCreateNote() {
   await createFile()
@@ -63,8 +64,8 @@ function renderRecentlyVisited() {
     .append($('<span>').text('Recently visited'))
   $inner.append($heading)
 
-  if (recentFiles.value.length === 0) {
-    // Empty state
+  if (recentFiles.value.length === 0 && !loading.value) {
+    // Empty state — only show after notes have finished loading
     $inner.append(
       $('<p>')
         .addClass('text-sm text-[var(--text-muted)]')

--- a/frontend/src/components/editor/EditorContent.vue
+++ b/frontend/src/components/editor/EditorContent.vue
@@ -63,7 +63,7 @@
       @blur="handleEditorBlur"
     />
   </div>
-  <div v-else class="empty-state">
+  <div v-else-if="!loading" class="empty-state">
     <FileText class="w-12 h-12 text-[var(--text-muted)]" />
     <p>No notes yet</p>
     <p class="sub">Your vault is empty. Create your first note and start building your knowledge base.</p>
@@ -87,7 +87,7 @@ const props = defineProps({
 
 const emit = defineEmits(['update', 'rename', 'createFirst'])
 
-const { updateItemIcon, state, setActiveFile, createFile, syncNoteLinks } = useEditorStore()
+const { updateItemIcon, state, setActiveFile, createFile, syncNoteLinks, loading } = useEditorStore()
 
 const pickerOpen = ref(false)
 const pickerPos = ref({ top: 0, left: 0 })

--- a/frontend/src/composables/useEditorStore.js
+++ b/frontend/src/composables/useEditorStore.js
@@ -85,7 +85,7 @@ function generateId() {
   return Date.now().toString(36) + Math.random().toString(36).slice(2, 8)
 }
 
-const state = reactive({ items: [], activeFileId: null })
+const state = reactive({ items: [], activeFileId: null, loading: true })
 
 // ─── Note link cache (noteId → { outbound: Set<id>, inbound: Set<id> }) ────────
 const noteLinkCache = reactive({})
@@ -156,7 +156,6 @@ export function useEditorStore() {
    * "recently visited" to sync. Otherwise keep client-side only.
    */
   async function setActiveFile(id) {
-    state.activeFileId = id
     const item = state.items.find(i => i.id === id && i.type === 'file')
     if (item) {
       item.lastVisitedAt = new Date().toISOString()
@@ -170,6 +169,8 @@ export function useEditorStore() {
           item.content = ''
         }
       }
+      // Set active ID only after content is ready so the editor watch fires with real content
+      state.activeFileId = id
       // Load note links if not yet cached
       if (!noteLinkCache[id]) {
         try {
@@ -355,6 +356,8 @@ export function useEditorStore() {
   }
 
   async function init() {
+    if (state.items.length > 0) return
+    state.loading = true
     try {
       const notes = await fetchNotes()
       const folders = state.items.filter(i => i.type === 'folder')
@@ -362,15 +365,18 @@ export function useEditorStore() {
       state.items.splice(0, state.items.length, ...folders, ...backendFiles)
       if (!state.items.find(i => i.id === state.activeFileId)) {
         const firstFile = state.items.find(i => i.type === 'file')
-        state.activeFileId = firstFile ? firstFile.id : null
+        if (firstFile) await setActiveFile(firstFile.id)
       }
     } catch (err) {
       console.warn('Failed to load notes from backend, using local data:', err.message)
+    } finally {
+      state.loading = false
     }
   }
 
   return {
     state,
+    loading: computed(() => state.loading),
     activeFile,
     rootItems,
     getChildren,


### PR DESCRIPTION
## Summary
- Add tag system backend: `DB_TAGS` + `DB_NOTE_TAGS` tables (migration v7), 5 new API endpoints for global and per-note tag management
- Fix blank editor on page refresh: `setActiveFile` now sets `activeFileId` after content is fetched
- Fix empty state flash: suppress "No notes yet" with a `loading` flag during `init()`
- Fix Dashboard empty on hard refresh: call `init()` from Dashboard with idempotency guard
- Fix seed script and FTS5 index: remove stale `tags` column reference