### PR TITLE
feat: rework tag system, fix calendar + editor bugs

### DIFF
--- a/backend/scripts/seedTestData.mjs
+++ b/backend/scripts/seedTestData.mjs
@@ -1075,7 +1075,6 @@ async function waitForBackend(retries = 20, intervalMs = 3000) {
 		try {
 			const res = await fetch(`${API}/health`);
 			if (res.ok) {
-				log("Backend is up.");
 				return;
 			}
 		} catch {
@@ -1090,25 +1089,10 @@ async function waitForBackend(retries = 20, intervalMs = 3000) {
 // ─── Main ─────────────────────────────────────────────────────────────────────
 
 async function main() {
-	log("─────────────────────────────────────");
-	log(" GraphNotes seed script");
-	log(`─────────────────────────────────────`);
-	log(`API: ${API}`);
-	log(`Notes to seed: ${NOTES.length}`);
-
 	await waitForBackend();
 
 	// 1. Register (ok to fail if user exists)
-	const reg = await post("/register", {
-		username: USERNAME,
-		email: EMAIL,
-		password: PASSWORD,
-	});
-	if (reg.ok) {
-		log(`Registered new user: ${USERNAME}`);
-	} else {
-		log(`User already exists, continuing...`);
-	}
+	await post("/register", { username: USERNAME, email: EMAIL, password: PASSWORD });
 
 	// 2. Login
 	const login = await post("/login", {
@@ -1117,7 +1101,6 @@ async function main() {
 	});
 	if (!login.ok) throw new Error(`Login failed (status ${login.status})`);
 	const token = login.data.token;
-	log(`Logged in as ${USERNAME}`);
 
 	// 3. Load existing tags (idempotency)
 	const existingTagsRes = await get("/tags", token);
@@ -1131,7 +1114,6 @@ async function main() {
 		const r = await post("/tags", { name }, token);
 		if (r.ok && r.data?.id) tagIdByName[name] = r.data.id;
 	}
-	log(`Tags ready: ${Object.keys(tagIdByName).length} total`);
 
 	// 4. Load existing notes (idempotency)
 	const existingNotesRes = await get("/notes", token);
@@ -1141,10 +1123,7 @@ async function main() {
 
 	let created = 0;
 	for (const note of NOTES) {
-		if (noteIdByTitle[note.title]) {
-			log(`  skip: "${note.title}" (already exists)`);
-			continue;
-		}
+		if (noteIdByTitle[note.title]) continue;
 		const tagLine = note.tags.length
 			? "\n\n" + note.tags.map((t) => `#${t}`).join(" ")
 			: "";
@@ -1153,10 +1132,7 @@ async function main() {
 			{ title: note.title, content: note.content + tagLine },
 			token,
 		);
-		if (!r.ok) {
-			log(`  WARN: failed to create "${note.title}"`);
-			continue;
-		}
+		if (!r.ok) continue;
 		const id = r.data?.id;
 		noteIdByTitle[note.title] = id;
 
@@ -1164,24 +1140,14 @@ async function main() {
 			await post(`/notes/${id}/tags`, { tags: note.tags }, token);
 		}
 
-		log(`  created: "${note.title}" (id: ${id})`);
 		created++;
 	}
-	log(`Notes: ${created} created, ${NOTES.length - created} skipped`);
-
 	// 5. Apply creation dates (always re-applied so re-running keeps timeline accurate)
-	log("Applying creation dates...");
 	for (const note of NOTES) {
 		const id = noteIdByTitle[note.title];
 		if (!id) continue;
-		const r = await post(
-			`/notes/${id}/created-at`,
-			{ created_at: note.created_at },
-			token,
-		);
-		if (!r.ok) log(`  WARN: failed to backdate "${note.title}"`);
+		await post(`/notes/${id}/created-at`, { created_at: note.created_at }, token);
 	}
-	log("Dates applied");
 
 	// 6. Create wiki-links
 	let linkCount = 0;
@@ -1196,12 +1162,8 @@ async function main() {
 			{ links: [{ from_id: fromId, to_ids: toIds }] },
 			token,
 		);
-		if (r.ok) {
-			log(`  linked: "${note.title}" → ${note.links.join(", ")}`);
-			linkCount += toIds.length;
-		}
+		if (r.ok) linkCount += toIds.length;
 	}
-	log(`Links: ${linkCount} created`);
 
 	// 7. Index notes for search
 	for (const note of NOTES) {
@@ -1213,18 +1175,7 @@ async function main() {
 			tags: note.tags.join(" "),
 		});
 	}
-	log("Search index updated");
-
-	log("");
-	log("─────────────────────────────────────");
-	log(" Seed complete!");
-	log(
-		` ${NOTES.length} notes · 2022–2026 · ${Object.keys(tagIdByName).length} tags`,
-	);
-	log(" Test credentials:");
-	log(`   username : ${USERNAME}`);
-	log(`   password : ${PASSWORD}`);
-	log("─────────────────────────────────────");
+	log(`Seed complete: ${created} created, ${NOTES.length - created} skipped, ${linkCount} links`);
 }
 
 main().catch((err) => {

--- a/backend/src/api/api_tag_post.ts
+++ b/backend/src/api/api_tag_post.ts
@@ -10,8 +10,8 @@ export const ApiPostTag = (req: AuthenticatedRequest, res: Response): void => {
 
 	const { name } = req.body as { name?: string };
 
-	if (!name || name.trim().length === 0) {
-		res.status(400).json({ message: "Tag name is required" });
+	if (!name || !/^[a-zA-Z0-9]{1,30}$/.test(name.trim())) {
+		res.status(400).json({ message: "Tag name must be alphanumeric and at most 30 characters" });
 		return;
 	}
 

--- a/frontend/src/components/editor/EditorContent.vue
+++ b/frontend/src/components/editor/EditorContent.vue
@@ -129,6 +129,7 @@ function handleIconSelect(iconName) {
 
 const editorRef = ref(null)
 let isUpdatingFromProp = false
+let lastEmittedContent = ''
 
 function formatDate(dateStr) {
   if (!dateStr) return ''
@@ -143,11 +144,22 @@ function formatDate(dateStr) {
 // When active file changes, load its content into the editor
 watch([() => props.file?.id, () => props.livePreview], () => {
   if (props.file && editorRef.value) {
+    lastEmittedContent = props.file.content ?? ''
     isUpdatingFromProp = true
     editorRef.value.innerHTML = contentToHtml(props.file.content)
     nextTick(() => { isUpdatingFromProp = false })
   }
 }, { immediate: true })
+
+// When content is updated externally (e.g. auto-tag writes to file), re-render the editor
+watch(() => props.file?.content, (newContent) => {
+  if (!editorRef.value || !props.file) return
+  if ((newContent ?? '') === lastEmittedContent) return  // editor itself caused this change
+  lastEmittedContent = newContent ?? ''
+  isUpdatingFromProp = true
+  editorRef.value.innerHTML = contentToHtml(newContent)
+  nextTick(() => { isUpdatingFromProp = false })
+})
 
 // Also handle initial mount
 watch(editorRef, (el) => {
@@ -180,7 +192,7 @@ function processLineContent(text) {
     `<code><span class="md-syntax" contenteditable="false">\`</span>${c}<span class="md-syntax" contenteditable="false">\`</span></code>`)
 
   // 6. Tags (#tagname — not # alone or # followed by space)
-  text = text.replace(/#([\w-]+)/g, (_, name) =>
+  text = text.replace(/#([a-zA-Z0-9]{1,30})/g, (_, name) =>
     `<span class="tag-link" contenteditable="false" data-tag="${name}">#${name}</span>`)
 
   // 7. Wiki-links (skip self-references)
@@ -496,6 +508,7 @@ function handleInput() {
   }
   const html = editorRef.value?.innerHTML || ''
   const markdown = htmlToContent(html)
+  lastEmittedContent = markdown
   emit('update', markdown)
   renderWikiLinksInDOM()
   renderTagsInDOM()
@@ -513,7 +526,7 @@ function handleKeydown(e) {
       const container = sel.getRangeAt(0).startContainer
       if (container.nodeType === Node.TEXT_NODE) {
         const textBefore = container.textContent.slice(0, sel.getRangeAt(0).startOffset)
-        const match = textBefore.match(/#([\w-]+)$/)
+        const match = textBefore.match(/#([a-zA-Z0-9]{1,30})$/)
         if (match) ensureGlobalTag(match[1].toLowerCase())
       }
     }
@@ -896,7 +909,7 @@ function checkTagAutocomplete() {
   if (container.nodeType !== Node.TEXT_NODE) { closeTagAutocomplete(); return }
 
   const textBefore = container.textContent.slice(0, range.startOffset)
-  const match = textBefore.match(/#([\w-]*)$/)
+  const match = textBefore.match(/#([a-zA-Z0-9]*)$/)
   if (!match) { closeTagAutocomplete(); return }
 
   const term = match[1].toLowerCase()
@@ -927,7 +940,7 @@ function selectTag(tagName) {
   if (container.nodeType !== Node.TEXT_NODE) return
 
   const textBefore = container.textContent.slice(0, range.startOffset)
-  const match = textBefore.match(/#([\w-]*)$/)
+  const match = textBefore.match(/#([a-zA-Z0-9]*)$/)
   if (!match) return
 
   const deleteRange = document.createRange()
@@ -969,12 +982,12 @@ function renderTagsInDOM() {
   while ((n = walker.nextNode())) {
     const parent = n.parentElement
     // Skip this node only if the cursor is mid-word inside a #tag — still typing
-    if (n === anchorNode && /#[\w-]*$/.test(n.textContent.slice(0, anchorOffset))) continue
+    if (n === anchorNode && /#[a-zA-Z0-9]*$/.test(n.textContent.slice(0, anchorOffset))) continue
     if (
       !parent?.classList.contains('tag-link') &&
       !parent?.classList.contains('wiki-link') &&
       !parent?.classList.contains('md-syntax') &&
-      /#([\w-]+)/.test(n.textContent)
+      /#([a-zA-Z0-9]{1,30})/.test(n.textContent)
     ) {
       nodes.push(n)
     }
@@ -985,7 +998,7 @@ function renderTagsInDOM() {
 
   for (const textNode of nodes) {
     const text = textNode.textContent
-    const regex = /#([\w-]+)/g
+    const regex = /#([a-zA-Z0-9]{1,30})/g
     const frag = document.createDocumentFragment()
     let last = 0
     let match

--- a/frontend/src/components/editor/EditorTagPanel.vue
+++ b/frontend/src/components/editor/EditorTagPanel.vue
@@ -12,16 +12,13 @@
       <div class="section-label">This note</div>
       <template v-if="activeFile">
         <div class="note-tags">
-          <span v-for="tag in panelTags" :key="'p-' + tag" class="tag-chip panel-tag">
+          <span v-for="tag in noteTags" :key="tag" class="tag-chip">
             #{{ tag }}
-            <button class="chip-remove" title="Remove tag" @click="removePanelTag(tag)">
+            <button class="chip-remove" title="Remove tag" @click="removeTag(tag)">
               <X class="w-2.5 h-2.5" />
             </button>
           </span>
-          <span v-for="tag in contentOnlyTags" :key="'c-' + tag" class="tag-chip content-tag" title="Remove from note content to delete">
-            #{{ tag }}
-          </span>
-          <span v-if="!panelTags.length && !contentOnlyTags.length" class="empty-msg">No tags yet</span>
+          <span v-if="!noteTags.length" class="empty-msg">No tags yet</span>
         </div>
         <button
           class="auto-tag-btn"
@@ -49,6 +46,7 @@
           placeholder="New tag..."
           maxlength="30"
           @input="sanitizeTagInput"
+          @paste.prevent="handleTagPaste"
           @keydown.enter="createNewTag"
           @keydown.escape="newTagName = ''"
         />
@@ -80,16 +78,19 @@ import { Plus, X, RefreshCw, Sparkles } from 'lucide-vue-next'
 import { useEditorStore } from '../../composables/useEditorStore.js'
 import { createTag, deleteTag, fetchTags, analyzeNote } from '../../services/api.js'
 
-const { globalTags, activeFile, setNoteTags, getPanelTags, getContentTags, deletePanelTag, reloadNoteTags } = useEditorStore()
+const {
+  globalTags,
+  activeFile,
+  addTagsToContent,
+  removeTagFromContent,
+  parseContentTags,
+  reloadNoteTags,
+} = useEditorStore()
 
-// Panel tags for active note (deletable)
-const panelTags = computed(() => activeFile.value ? getPanelTags(activeFile.value.id) : [])
-// Content tags not already in panel (shown read-only)
-const contentOnlyTags = computed(() => {
-  if (!activeFile.value) return []
-  const panel = new Set(getPanelTags(activeFile.value.id))
-  return getContentTags(activeFile.value.id).filter(t => !panel.has(t))
-})
+// All tags for the active note, read directly from file content
+const noteTags = computed(() =>
+  activeFile.value ? parseContentTags(activeFile.value.content ?? '') : []
+)
 
 const newTagName = ref('')
 const error = ref('')
@@ -102,7 +103,13 @@ async function refreshTags() {
 }
 
 function sanitizeTagInput() {
-  newTagName.value = newTagName.value.replace(/[^a-zA-Z0-9]/g, '')
+  newTagName.value = newTagName.value.replace(/[^a-zA-Z0-9]/g, '').slice(0, 30)
+}
+
+function handleTagPaste(e) {
+  const pasted = e.clipboardData.getData('text')
+  const sanitized = pasted.replace(/[^a-zA-Z0-9]/g, '')
+  newTagName.value = (newTagName.value + sanitized).slice(0, 30)
 }
 
 async function createNewTag() {
@@ -121,19 +128,15 @@ async function createNewTag() {
     await createTag(name)
     newTagName.value = ''
     await refreshTags()
-  } catch (err) {
+  } catch {
     error.value = 'Failed to create tag'
   }
 }
 
-async function removePanelTag(tagName) {
+function removeTag(tagName) {
   if (!activeFile.value) return
   error.value = ''
-  try {
-    await deletePanelTag(activeFile.value.id, tagName)
-  } catch {
-    error.value = 'Failed to remove tag'
-  }
+  removeTagFromContent(activeFile.value.id, tagName)
 }
 
 async function autoTag() {
@@ -145,7 +148,7 @@ async function autoTag() {
   try {
     const { tags } = await analyzeNote(id, content, globalTags.map(t => t.name))
     const validTags = tags.filter(t => globalTags.some(g => g.name === t))
-    await setNoteTags(id, validTags)
+    addTagsToContent(id, validTags)
   } catch {
     error.value = 'Auto-tag failed'
   } finally {
@@ -158,7 +161,7 @@ async function deleteGlobalTag(tag) {
   try {
     await deleteTag(tag.id)
     await refreshTags()
-  } catch (err) {
+  } catch {
     error.value = 'Failed to delete tag'
   }
 }
@@ -224,6 +227,7 @@ async function deleteGlobalTag(tag) {
   gap: 6px;
   align-items: center;
 }
+
 .char-count {
   display: block;
   font-size: 11px;
@@ -231,6 +235,7 @@ async function deleteGlobalTag(tag) {
   text-align: right;
   margin-top: 3px;
 }
+
 .char-count.at-limit {
   color: #f87171;
 }
@@ -329,6 +334,7 @@ async function deleteGlobalTag(tag) {
   flex-wrap: wrap;
   gap: 5px;
   min-height: 20px;
+  margin-top: 6px;
 }
 
 .tag-chip {
@@ -341,10 +347,6 @@ async function deleteGlobalTag(tag) {
   font-weight: 500;
   color: var(--tag-color);
   background: var(--tag-bg);
-}
-
-.content-tag {
-  opacity: 0.6;
 }
 
 .chip-remove {
@@ -387,6 +389,21 @@ async function deleteGlobalTag(tag) {
   display: flex;
   flex-direction: column;
   gap: 1px;
+  scrollbar-width: thin;
+  scrollbar-color: var(--border) var(--surface);
+}
+
+.tag-list::-webkit-scrollbar {
+  width: 6px;
+}
+
+.tag-list::-webkit-scrollbar-track {
+  background: var(--surface);
+}
+
+.tag-list::-webkit-scrollbar-thumb {
+  background: var(--border);
+  border-radius: 3px;
 }
 
 .empty-msg {

--- a/frontend/src/components/visualizations/SentimentCalendar.vue
+++ b/frontend/src/components/visualizations/SentimentCalendar.vue
@@ -36,7 +36,7 @@ function getCellSize() {
 }
 
 const activityScale = computed(() =>
-  d3.scaleSequential(d3.interpolateBlues).domain([0, maxActivityCount])
+  d3.scaleSequential(d3.interpolateBlues).domain([0, maxPerDay.value])
 )
 
 const emptyColor = computed(() => isDark.value ? '#1e293b' : '#e2e8f0')

--- a/frontend/src/composables/useEditorStore.js
+++ b/frontend/src/composables/useEditorStore.js
@@ -74,10 +74,12 @@ const panelTagCache   = reactive({})
 const globalTags      = reactive([]) 
 
 function parseContentTags(content) {
-  const tagRegex = /#([\w-]+)/g
+  const tagRegex = /#([a-zA-Z0-9]+)/g
   const found = new Set()
   let match
-  while ((match = tagRegex.exec(content)) !== null) found.add(match[1].toLowerCase())
+  while ((match = tagRegex.exec(content)) !== null) {
+    if (match[1].length <= 30) found.add(match[1].toLowerCase())
+  }
   return [...found]
 }
 
@@ -100,6 +102,7 @@ async function syncContentTags(noteId, content) {
 
 
 async function ensureGlobalTag(name) {
+  if (!/^[a-zA-Z0-9]{1,30}$/.test(name)) return
   if (globalTags.find(t => t.name === name)) return
   try {
     const result = await createTag(name)
@@ -251,6 +254,14 @@ export function useEditorStore() {
     indexNote(id, { title, content }).catch(err => {
       console.warn('Failed to index imported note:', err.message)
     })
+    // Register any #hashtags found in imported content as global tags and sync to note
+    const contentTags = parseContentTags(content)
+    if (contentTags.length) {
+      await Promise.all(contentTags.map(t => ensureGlobalTag(t)))
+      const fresh = await fetchTags()
+      globalTags.splice(0, globalTags.length, ...fresh)
+      await syncContentTags(id, content)
+    }
     return id
   }
 
@@ -431,6 +442,24 @@ export function useEditorStore() {
     globalTags.splice(0, globalTags.length, ...fresh)
   }
 
+  function addTagsToContent(noteId, tagNames) {
+    const item = state.items.find(i => i.id === noteId && i.type === 'file')
+    if (!item) return
+    const existing = new Set(parseContentTags(item.content ?? ''))
+    const toAdd = tagNames.filter(t => !existing.has(t.toLowerCase()))
+    if (!toAdd.length) return
+    const newContent = (item.content ?? '').trimEnd() + '\n' + toAdd.map(t => `#${t}`).join(' ')
+    updateFileContent(noteId, newContent)
+  }
+
+  function removeTagFromContent(noteId, tagName) {
+    const item = state.items.find(i => i.id === noteId && i.type === 'file')
+    if (!item) return
+    const pattern = new RegExp(`\\s*#${tagName}(?=[\\s,;.!?\\n]|$)`, 'gi')
+    const newContent = (item.content ?? '').replace(pattern, '').replace(/\n{3,}/g, '\n\n').trimEnd()
+    updateFileContent(noteId, newContent)
+  }
+
   function getLinkedNotes(noteId) {
     const cache = noteLinkCache[noteId]
     if (!cache) return { outbound: [], inbound: [] }
@@ -495,6 +524,9 @@ export function useEditorStore() {
     deletePanelTag,
     reloadNoteTags,
     ensureGlobalTag,
+    addTagsToContent,
+    removeTagFromContent,
+    parseContentTags,
     init,
   }
 }


### PR DESCRIPTION
## Summary
- Tags are now file-content driven: all tags (user & Gemini) stored as `#hashtags` in the note; auto-tag appends to file instead of DB-only
- Unified "This note" tag display — no more panel vs content split
- File import now registers `#hashtags` as global tags automatically
- Consistent `^[a-zA-Z0-9]{1,30}$` validation across all tag entry points (editor keydown, panel input, paste, `ensureGlobalTag`, backend API)
- Fix: editor didn't re-render when content was updated externally (auto-tag now reflects immediately)
- Fix: calendar activity color scale was non-reactive (`maxActivityCount` plain var → use `maxPerDay` ref)
- Seed script output reduced to single summary line
